### PR TITLE
[CB-221]회원가입 완료 여부 API를 code와 함께 리턴하도록 수정

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -300,11 +300,13 @@ const isSetNickname = async (req, res, next) => {
       if(user.nick!=null){
         logger.info(`GET users/check/:userId | userId : ${req.params.userId} 는 회원가입을 완료한 회원입니다.`);
         result.setNickname=true;
+        return jsonResponse(res, 200, `[회원가입 완료 여부]${req.params.userId} 는 회원가입을 완료한 회원입니다. 홈 화면으로 리다이렉트합니다.`, true, result); // #swagger.responses[200]
       }
       else{
         logger.info(`GET users/check/:userId | userId : ${req.params.userId} 는 회원가입을 완료하지 않은 회원입니다.`);
+        return jsonResponse(res, 300, `[회원가입 완료 여부]${req.params.userId} 는 회원가입을 완료하지 않은 회원입니다. 약관동의 화면으로 리다이렉트합니다.`, true, result); // #swagger.responses[200]
       }
-      return jsonResponse(res, 200, "[회원가입 완료 여부]userId의 회원가입 완료 여부를 반환합니다.", true, result); // #swagger.responses[200]
+      
     }
   } catch (error) {
     logger.error(error);

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -446,10 +446,12 @@ router.get('/apple/signout', verifyToken, async (req, res, next) => {
 router.get('/kakao/logout',async(req,res,next)=>{
   // #swagger.summary = '카카오 웹뷰 로그아웃'
   try {
-    return jsonResponse(res, 200, '카카오 로그아웃 성공', true, null);
+    res.status(200).send();
+    //return jsonResponse(res, 200, '카카오 로그아웃 성공', true, null);
   } catch (error) {
     logger.error(error);
-    return jsonResponse(res, 500, "서버 에러", false, null);
+    res.status(500).send();
+    //return jsonResponse(res, 500, "서버 에러", false, null);
   }
 })
 

--- a/swagger/swagger-test.json
+++ b/swagger/swagger-test.json
@@ -210,11 +210,7 @@
         "summary": "애플 로그인 CallBack",
         "description": "",
         "parameters": [],
-        "responses": {
-          "200": {
-            "description": "OK"
-          }
-        }
+        "responses": {}
       }
     },
     "/auth/success": {
@@ -698,36 +694,6 @@
         "parameters": [
           {
             "name": "userId",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "nick": {
-                  "example": "any"
-                }
-              }
-            }
-          }
-        ],
-        "responses": {}
-      }
-    },
-    "/users/kakaosdk/{kakaoNumber}": {
-      "put": {
-        "tags": [
-          "Users"
-        ],
-        "summary": "카카오 유저 닉네임 변경",
-        "description": "",
-        "parameters": [
-          {
-            "name": "kakaoNumber",
             "in": "path",
             "required": true,
             "type": "string"


### PR DESCRIPTION
[CB-221]
회원가입 완료 여부 API를 loginWithKakaoSdk API와의 통일성을 위해 회원가입을 완료하지 않았으면 300, 회원가입을 완료했으면 200 을 반환.
200 : 홈 화면 이동
300 : 약관 동의 화면 이동

[CB-221]: https://chocobread.atlassian.net/browse/CB-221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ