### PR TITLE
[CB-226]애플 회원탈퇴 api 메서드 get->delete로 변경

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -391,7 +391,7 @@ router.get('/naver/reauth', async (req, res, next) => {
   }
 })
 
-router.get('/apple/signout', verifyToken, async (req, res, next) => {
+router.delete('/apple/signout', verifyToken, async (req, res, next) => {
   // #swagger.summary = '애플 회원탈퇴'
   const nowSec = await Math.round(new Date().getTime() / 1000);
   const expirySec = 120000;


### PR DESCRIPTION
[CB-226]
프론트에서 회원탈퇴기능 구현 중 카카오sdk 탈퇴는 delete, 애플 회원 탈퇴는 get인것을 발견. api의 통일성을 위해 apple signout api를 get방식에서 delete방식으로 변경

[CB-226]: https://chocobread.atlassian.net/browse/CB-226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ