### PR TITLE
[CB-269] getUserApi가 loc1 2도 함께 반환하도록 변경

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -33,10 +33,12 @@ const getUser = async (req, res, next) => {
             createdAt : user.createdAt,
             nick : user.nick,
             provider : user.provider,
-            addr : user.curLocation3,
             deletedAt:user.deletedAt,
             id : user.id,
             email : user.email,
+            loc1: user.curLocation1,
+            loc2: user.curLocation2,
+            addr: user.curLocation3,
         }
         logger.info(`GET users/:userId | userId : ${req.params.userId} 의 유저 정보를 반환합니다.`);
         return jsonResponse(res, 200, "userId의 정보를 반환합니다.", true, result); // #swagger.responses[200]


### PR DESCRIPTION
[CB-269]
로컬스토리지에 loc 123을 저장하기 위해 getUserApi가 loc1 2도 함께 반환하도록 변경

[CB-269]: https://chocobread.atlassian.net/browse/CB-269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ