### PR TITLE
[CB-270] (Old) 홈 모든 거래 광고 적용 위해 동단위 -> 구단위로 변경

### DIFF
--- a/swagger/swagger-test.json
+++ b/swagger/swagger-test.json
@@ -627,8 +627,7 @@
         "summary": "관리자 : deals Table loc1,2,3",
         "description": "",
         "parameters": [],
-        "responses": {},
-        "deprecated": true
+        "responses": {}
       }
     },
     "/users/deals/{userId}": {


### PR DESCRIPTION
## [CB-270]

1.
배열로 구안의 동을 모두 선언한뒤 for문으로 임시 처리.
다음 릴리즈 9/23 2.0.1버전에서는 새로운 홈 모든 거래 API로 변경해야됨.

2.
홈 모든 거래 불러오는 순서 변경.
예시) 현재 강남구 역삼동

1순위 : 현재 위치한 region (강남구)
2순위 : 공유하는 region (서초구)
3순위 : global

![image](https://user-images.githubusercontent.com/43171709/191564146-7a7cd82a-3fe7-481d-b38d-728f2fdbe37b.png)

[CB-270]: https://chocobread.atlassian.net/browse/CB-270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ